### PR TITLE
Code style & fixes for update scripts, small note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This script automatically updates:
     - Updated with [cargo-update](https://crates.io/crates/cargo-update).
 - `snap` projects.
 - `tldr` cache.
-- A global [Gradle](https://gradle.org) installation.
+- A global [Gradle](https://gradle.org) installation (installs to `/opt/gradle/`).
 
 This is intended to be as easy as possible to extend. If an update 'group' is not listed here, it should be easy to add.
 

--- a/src/update.sh
+++ b/src/update.sh
@@ -42,13 +42,11 @@ pinned=""
 [ -f "$pin_file" ] && pinned=$(cat "$pin_file")
 
 function message() {
-    highlight_color="$1"
-    text_color="$2"
+    local highlight_color="$1"
+    local text_color="$2"
     shift 2
 
     echo -e "\n${colors[$highlight_color]}${colors[$text_color]} $* ${colors[reset]}\n"
-
-    unset highlight_color text_color
 }
 
 function header() {
@@ -65,7 +63,7 @@ function pinned() {
 }
 
 function section() {
-    name="$1"
+    local name="$1"
     shift
 
     header "Updating '$name'..."
@@ -82,7 +80,7 @@ function section() {
         echo -e "> ${colors[italics]}$command${colors[reset]}\n"
 
         $command || {
-            exit_code=$?
+            local exit_code=$?
             failure "Failed to update '$name'!"
 
             return $exit_code


### PR DESCRIPTION
# `update-gradle.sh`
- Fixed guidance on modifying `$PATH`
- Used `local` for variables in functions
- Simplified fail checks
- Expanded args (e.g. `curl -s` to `curl --silent`)
- Miscellaneous changes to Bash-specific syntax

# `update.sh`
- Used `local` for variables in functions

# `README.md`
- Added note that Gradle installs to `/opt/gradle/`

---

No spiders 🕷️🕸️